### PR TITLE
inefficent-save-fix-correction

### DIFF
--- a/src/dataanalyzer/DataAnalyzer.java
+++ b/src/dataanalyzer/DataAnalyzer.java
@@ -2177,10 +2177,10 @@ public class DataAnalyzer extends javax.swing.JFrame {
             new MessageBox(this, "Error: Files could not be compared", true).setVisible(true);
         }
         
-        Path tempPath = Paths.get(filename);
-        Path origPath = Paths.get(fileDirectory);
+        Path tempPath = Paths.get(fileDirectory);
+        Path origPath = Paths.get(filename);
         // only saves changes in the temp file to the original if the save button was pressed
-        if( fileWasSaved == true ){
+        if(fileWasSaved == true){
           try {
               Files.move(tempPath, origPath, StandardCopyOption.REPLACE_EXISTING);
           } catch(IOException e){
@@ -2374,10 +2374,10 @@ public class DataAnalyzer extends javax.swing.JFrame {
             new MessageBox(this, "Error: Files could not be compared", true).setVisible(true);
         }
        
-        Path tempPath = Paths.get(filename);
-        Path origPath = Paths.get(fileDirectory);
+        Path tempPath = Paths.get(fileDirectory);
+        Path origPath = Paths.get(filename);
         // only saves changes in the temp file to the original if the save button was pressed
-        if( fileWasSaved == true ){
+        if(fileWasSaved == true){
           try {
               Files.move(tempPath, origPath, StandardCopyOption.REPLACE_EXISTING);
           } catch(IOException e){


### PR DESCRIPTION
Interchanged path of the temporary file and current dfr file as the two were in the wrong order in order to correctly use .move method so that the dfr file is saved in the same place instead of where the temp file should be.